### PR TITLE
return correct content-types for swagger-ui files

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -4,9 +4,10 @@ import (
 	"html/template"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/labstack/echo/v4"
-	"github.com/swaggo/files"
+	swaggerFiles "github.com/swaggo/files"
 	"github.com/swaggo/swag"
 )
 
@@ -58,6 +59,18 @@ func EchoWrapHandler(confs ...func(c *Config)) echo.HandlerFunc {
 		path := matches[2]
 		prefix := matches[1]
 		handler.Prefix = prefix
+
+		if strings.HasSuffix(path, ".html") {
+			c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+		} else if strings.HasSuffix(path, ".css") {
+			c.Response().Header().Set("Content-Type", "text/css; charset=utf-8")
+		} else if strings.HasSuffix(path, ".js") {
+			c.Response().Header().Set("Content-Type", "application/javascript")
+		} else if strings.HasSuffix(path, ".json") {
+			c.Response().Header().Set("Content-Type", "application/json")
+		} else if strings.HasSuffix(path, ".png") {
+			c.Response().Header().Set("Content-Type", "image/png")
+		}
 
 		switch path {
 		case "index.html":

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -17,16 +17,26 @@ func TestWrapHandler(t *testing.T) {
 
 	w1 := performRequest("GET", "/index.html", router)
 	assert.Equal(t, 200, w1.Code)
+	assert.Equal(t, "text/html; charset=utf-8", w1.Header().Get("Content-Type"))
 
 	w2 := performRequest("GET", "/doc.json", router)
 	assert.Equal(t, 200, w2.Code)
+	assert.Equal(t, "application/json", w2.Header().Get("Content-Type"))
 
 	w3 := performRequest("GET", "/favicon-16x16.png", router)
 	assert.Equal(t, 200, w3.Code)
+	assert.Equal(t, "image/png", w3.Header().Get("Content-Type"))
 
-	w4 := performRequest("GET", "/notfound", router)
-	assert.Equal(t, 404, w4.Code)
+	w4 := performRequest("GET", "/swagger-ui-bundle.js", router)
+	assert.Equal(t, 200, w4.Code)
+	assert.Equal(t, "application/javascript", w4.Header().Get("Content-Type"))
 
+	w5 := performRequest("GET", "/swagger-ui.css", router)
+	assert.Equal(t, 200, w5.Code)
+	assert.Equal(t, "text/css; charset=utf-8", w5.Header().Get("Content-Type"))
+
+	w6 := performRequest("GET", "/notfound", router)
+	assert.Equal(t, 404, w6.Code)
 }
 
 func performRequest(method, target string, e *echo.Echo) *httptest.ResponseRecorder {


### PR DESCRIPTION
I was using the "Secure middleware" from echo together with echo-swagger. The result was a blank screen. 
The option `X-Content-Type-Options: nosniff` complained, that the *.js files did not have the correct `Content-Type`. Which is true as seen in the screenshot:

![image](https://user-images.githubusercontent.com/635852/62006105-83dd8e00-b13c-11e9-97ce-896793b83929.png)

they were delivered using `Content-Type: text/plain; charset=utf-8`

![image](https://user-images.githubusercontent.com/635852/62006130-ed5d9c80-b13c-11e9-9273-b22503554168.png)

I poked around and found that the gin-swagger implementation takes care of this (https://github.com/swaggo/gin-swagger/blob/master/swagger.go)

My PR just copies the logic of gin-swagger resulting in correct Content-Types which work with "nosniff"

![image](https://user-images.githubusercontent.com/635852/62006155-5218f700-b13d-11e9-8dd8-170d0b3647ce.png)



