### PR TITLE
Fix test fail due to invalid path to example docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
 
 matrix:
   fast_finish: true

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
-	_ "github.com/swaggo/gin-swagger/example/docs"
+	_ "github.com/swaggo/gin-swagger/example/basic/docs"
 )
 
 func TestWrapHandler(t *testing.T) {


### PR DESCRIPTION
The path to the example docs for gin-swagger has changed, causing the
tests to fail. This fixes the example docs path.