### PR TITLE
Fix wwindow.onload to be window.onload

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -179,7 +179,7 @@ const indexTempl = `<!-- HTML for static distribution bundle build -->
 <script src="./swagger-ui-bundle.js"> </script>
 <script src="./swagger-ui-standalone-preset.js"> </script>
 <script>
-wwindow.onload = function() {
+window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
     url: "{{.URL}}",


### PR DESCRIPTION
Fix what is presumably a typo.  Just pulled the latest and it's whitescreening because of this.