### PR TITLE
suppress deprecation message during swag install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ echo middleware to automatically generate RESTful API documentation with Swagger
 1. Add comments to your API source code, [See Declarative Comments Format](https://github.com/swaggo/swag#declarative-comments-format).
 2. Download [Swag](https://github.com/swaggo/swag) for Go by using:
 ```sh
-$ go get github.com/swaggo/swag/cmd/swag
+$ go get -d github.com/swaggo/swag/cmd/swag
 ```
 3. Run the [Swag](https://github.com/swaggo/swag) in your Go project root folder which contains `main.go` file, [Swag](https://github.com/swaggo/swag) will parse comments and generate required files(`docs` folder and `docs/doc.go`).
 ```sh_ "github.com/swaggo/echo-swagger/v2/example/docs"


### PR DESCRIPTION
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

**Describe the PR**
e.g. add cool parser.

**Relation issue**
e.g. https://github.com/swaggo/gin-swagger/pull/123/files

**Additional context**
Add any other context about the problem here.
