### PR TITLE
fix: it is better to return the error with c.Error

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -2,7 +2,6 @@ package echoSwagger
 
 import (
 	"html/template"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"sync"
@@ -105,7 +104,7 @@ func EchoWrapHandler(configFns ...func(c *Config)) echo.HandlerFunc {
 		case "doc.json":
 			doc, err := swag.ReadDoc()
 			if err != nil {
-				http.Error(c.Response().Writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				c.Error(err)
 
 				return nil
 			}


### PR DESCRIPTION
**Describe the PR**
If there is an error reading the doc.json file, then a 500 status code and context as plain/text is returned without any error information. 

```
% curl -vs http://localhost:8080/api/swagger/doc.json
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /api/swagger/doc.json HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 27 Oct 2021 12:10:47 GMT
< Transfer-Encoding: chunked
<
Internal Server Error
```

it is better to return the error using c.Error:
```
% curl -vs http://localhost:8080/api/swagger/doc.json
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /api/swagger/doc.json HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json; charset=utf-8
< Date: Wed, 27 Oct 2021 12:11:07 GMT
< Transfer-Encoding: chunked
<
{"error":"not yet registered swag"}
```