### PR TITLE
Added RedirectUrl into swagger.go to enable custom redirect URL

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -20,6 +20,7 @@ type Config struct {
 	DeepLinking  bool
 	DocExpansion string
 	DomID        string
+	RedirectUrl  interface{}
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -50,6 +51,13 @@ func DomID(domID string) func(c *Config) {
 	}
 }
 
+// Redirect URL for oauth2-redirect
+func RedirectUrl(redirectUrl string) func(c *Config) {
+	return func(c *Config) {
+		c.RedirectUrl = redirectUrl
+	}
+}
+
 // WrapHandler wraps swaggerFiles.Handler and returns echo.HandlerFunc
 var WrapHandler = EchoWrapHandler()
 
@@ -62,6 +70,7 @@ func EchoWrapHandler(configFns ...func(c *Config)) echo.HandlerFunc {
 		DeepLinking:  true,
 		DocExpansion: "list",
 		DomID:        "#swagger-ui",
+		RedirectUrl:  nil,
 	}
 
 	for _, configFn := range configFns {
@@ -208,6 +217,9 @@ window.onload = function() {
     docExpansion: "{{.DocExpansion}}",
     dom_id: "{{.DomID}}",
     validatorUrl: null,
+	{{if .RedirectUrl}}
+		oauth2RedirectUrl: {{.RedirectUrl}},
+	{{end}}
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset


### PR DESCRIPTION
**Describe the PR**
Currently echo-swagger assumes the Redirect URL used in OAuth2 process flow is at the root. Thus in the case of when Swagger UI is not root, the redirection would not work and result in `404 Not Found` returned. This PR will enable a new parameter RedirectUrl parameter and can be used along with the `EchoWrapHandler` so it can overwritten if necessary.

**Relation issue**
None - new feature

**Additional context**
If the RedirectURL parameter is not set, it will simply take the existing echo-swagger functions.