### PR TITLE
add setting/function to enable/disable syntax highlighting

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -22,6 +22,7 @@ type Config struct {
 	InstanceName         string
 	DeepLinking          bool
 	PersistAuthorization bool
+	SyntaxHighlight      bool
 
 	// The information for OAuth2 integration, if any.
 	OAuth *OAuthConfig
@@ -51,6 +52,13 @@ func URL(url string) func(*Config) {
 func DeepLinking(deepLinking bool) func(*Config) {
 	return func(c *Config) {
 		c.DeepLinking = deepLinking
+	}
+}
+
+// SyntaxHighlight true, false.
+func SyntaxHighlight(syntaxHighlight bool) func(*Config) {
+	return func(c *Config) {
+		c.SyntaxHighlight = syntaxHighlight
 	}
 }
 
@@ -97,6 +105,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		InstanceName:         "swagger",
 		DeepLinking:          true,
 		PersistAuthorization: false,
+		SyntaxHighlight:      true,
 	}
 
 	for _, fn := range configFns {
@@ -257,6 +266,7 @@ window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
     url: "{{.URL}}",
+    syntaxHighlight: {{.SyntaxHighlight}},
     deepLinking: {{.DeepLinking}},
     docExpansion: "{{.DocExpansion}}",
     persistAuthorization: {{.PersistAuthorization}},

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -374,6 +374,13 @@ func TestDeepLinking(t *testing.T) {
 	assert.Equal(t, expected, cfg.DeepLinking)
 }
 
+func TestSyntaxHighlight(t *testing.T) {
+	var cfg Config
+	expected := true
+	SyntaxHighlight(expected)(&cfg)
+	assert.Equal(t, expected, cfg.SyntaxHighlight)
+}
+
 func TestDocExpansion(t *testing.T) {
 	var cfg Config
 	expected := "https://github.com/swaggo/docs"


### PR DESCRIPTION
**Describe the PR**

Expose the syntax highlighting enable/disable option from swagger UI.

This PR sets the default value at true, retaining the current behavior if the option is not set.

**Relation issue**
N/A

**Additional context**
Exposing this option is necessary when dealing with large payload, otherwise, the syntax highlighting hangs swagger ui.

https://stackoverflow.com/questions/63615230/swagger-ui-hangs-on-big-responses
