### PR TITLE
chore: drop go 1.15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.15.x', '1.16.x', '1.17.x', '1.18.x' ]
+        go: [ '1.16.x', '1.17.x', '1.18.x' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
**Describe the PR**
Drop go 1.15 support

**Relation issue**
None

**Additional context**
None.
