### PR TITLE
feat: add oauth config setting to enable/disable pkce extension

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -39,6 +39,9 @@ type OAuthConfig struct {
 
 	// The name to display for the application in the authentication popup.
 	AppName string
+
+	// Use the Proof Key for Code Exchange extension to the authorization code flow
+	UsePkce bool
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -286,7 +289,8 @@ window.onload = function() {
   ui.initOAuth({
     clientId: "{{.OAuth.ClientId}}",
     realm: "{{.OAuth.Realm}}",
-    appName: "{{.OAuth.AppName}}"
+    appName: "{{.OAuth.AppName}}",
+    usePkceWithAuthorizationCodeGrant: {{.OAuth.UsePkce}}
   })
   {{end}}
 

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -304,7 +304,8 @@ func TestConfigWithOAuth(t *testing.T) {
 	assert.Contains(t, body, `ui.initOAuth({
     clientId: "my-client-id",
     realm: "my-realm",
-    appName: "My App Name"
+    appName: "My App Name",
+    usePkceWithAuthorizationCodeGrant:  false 
   })`)
 }
 
@@ -419,11 +420,13 @@ func TestOAuth(t *testing.T) {
 		ClientId: "my-client-id",
 		Realm:    "my-realm",
 		AppName:  "My App Name",
+		UsePkce:  true,
 	}
 	OAuth(&expected)(&cfg)
 	assert.Equal(t, expected.ClientId, cfg.OAuth.ClientId)
 	assert.Equal(t, expected.Realm, cfg.OAuth.Realm)
 	assert.Equal(t, expected.AppName, cfg.OAuth.AppName)
+	assert.Equal(t, expected.UsePkce, cfg.OAuth.UsePkce)
 }
 
 func TestOAuthNil(t *testing.T) {


### PR DESCRIPTION
**Describe the PR**
Add Proof Key for Code Exchange Support configurable with the OAuthConfig struct.

**Relation issue**
https://github.com/swaggo/echo-swagger/issues/99

**Additional context**
OAuth2 clients that only support Authorization Code Flow with PKCE do not work with the current feature set of echo-swagger.
There is a flag for it in Swagger UI 3.24.0+: usePkceWithAuthorizationCodeGrant and these small changes fix the problem.
