### PR TITLE
fixed bug with redirect from swagger/ to index.html

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -3,6 +3,7 @@ package echoSwagger
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"regexp"
 
@@ -158,7 +159,8 @@ func EchoWrapHandler(options ...func(*Config)) echo.HandlerFunc {
 
 		switch path {
 		case "":
-			_ = c.Redirect(http.StatusMovedPermanently, matches[1]+"/"+"index.html")
+			indexUrl, _ := url.JoinPath(c.Request().RequestURI, "index.html")
+			_ = c.Redirect(http.StatusMovedPermanently, indexUrl)
 		case "index.html":
 			_ = index.Execute(c.Response().Writer, config)
 		case "doc.json":


### PR DESCRIPTION
Fixed bug with redirect from swagger/ to index.html through proxy with changed prefix

I have:
-  service with swagger http://localhost:8080/service1/swagger/
- proxy as nginx with configured location /containers/ to my service

Url to swagger through proxy http://localhost:80/containers/service1/swagger/

A call to this URL will be redirected to http://localhost:80/service1/swagger/index.html. We have lost part of the URL

nginx config:
```
       location /containers/ {
            proxy_pass 		http://localhost:8080/;
            proxy_set_header	X-Real-IP           	$remote_addr;
	    proxy_set_header	X-Forwarded-For     	$proxy_add_x_forwarded_for;
	    proxy_set_header	X-Forwarded-Proto   	http;
	    proxy_set_header	X-Forwarded-Prefix	/containers/;
	    proxy_set_header	X-Forwarded-Port    	80;
	    proxy_set_header	X-Forwarded-Host    	$host;
        }
```