### PR TITLE
feat: add feature to expose yaml format OpenAPI document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=

--- a/swagger.go
+++ b/swagger.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/ghodss/yaml"
 	"github.com/labstack/echo/v4"
 	swaggerFiles "github.com/swaggo/files/v2"
 	"github.com/swaggo/swag"
@@ -146,6 +147,8 @@ func EchoWrapHandler(options ...func(*Config)) echo.HandlerFunc {
 			c.Response().Header().Set("Content-Type", "application/javascript")
 		case ".json":
 			c.Response().Header().Set("Content-Type", "application/json; charset=utf-8")
+		case ".yaml":
+			c.Response().Header().Set("Content-Type", "text/plain; charset=utf-8")
 		case ".png":
 			c.Response().Header().Set("Content-Type", "image/png")
 		}
@@ -170,7 +173,20 @@ func EchoWrapHandler(options ...func(*Config)) echo.HandlerFunc {
 			}
 
 			_, _ = c.Response().Writer.Write([]byte(doc))
+		case "doc.yaml":
+			jsonString, err := swag.ReadDoc(config.InstanceName)
+			if err != nil {
+				c.Error(err)
 
+				return nil
+			}
+			doc, err := yaml.JSONToYAML([]byte(jsonString))
+			if err != nil {
+				c.Error(err)
+
+				return nil
+			}
+			_, _ = c.Response().Writer.Write(doc)
 		default:
 			c.Request().URL.Path = matches[2]
 			http.FileServer(http.FS(swaggerFiles.FS)).ServeHTTP(c.Response(), c.Request())

--- a/swagger.go
+++ b/swagger.go
@@ -15,7 +15,7 @@ import (
 // Config stores echoSwagger configuration variables.
 type Config struct {
 	// The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `mockedSwag.json`.
-	URL                  string
+	URLs                 []string
 	DocExpansion         string
 	DomID                string
 	InstanceName         string
@@ -43,7 +43,7 @@ type OAuthConfig struct {
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
 func URL(url string) func(*Config) {
 	return func(c *Config) {
-		c.URL = url
+		c.URLs = append(c.URLs, url)
 	}
 }
 
@@ -98,7 +98,7 @@ func OAuth(config *OAuthConfig) func(*Config) {
 
 func newConfig(configFns ...func(*Config)) *Config {
 	config := Config{
-		URL:                  "doc.json",
+		URLs:                 []string{"doc.json", "doc.yaml"},
 		DocExpansion:         "list",
 		DomID:                "swagger-ui",
 		InstanceName:         "swagger",
@@ -270,7 +270,14 @@ const indexTemplate = `<!-- HTML for static distribution bundle build -->
 window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "{{.URL}}",
+	urls: [
+	{{range $index, $url := .URLs}}
+		{
+			name: "{{$url}}",
+			url: "{{$url}}",
+		},
+	{{end}}
+	],
     syntaxHighlight: {{.SyntaxHighlight}},
     deepLinking: {{.DeepLinking}},
     docExpansion: "{{.DocExpansion}}",

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -364,7 +364,7 @@ func TestURL(t *testing.T) {
 	var cfg Config
 	expected := "https://github.com/swaggo/http-swagger"
 	URL(expected)(&cfg)
-	assert.Equal(t, expected, cfg.URL)
+	assert.Equal(t, expected, cfg.URLs[0])
 }
 
 func TestDeepLinking(t *testing.T) {


### PR DESCRIPTION
**Describe the PR**
add feature to expose yaml format OpenAPI document.

You can see yaml formatted openapi document at "/swagger/doc.yaml" endpoint.

**Relation issue**
https://github.com/swaggo/echo-swagger/issues/109

**Additional context**
It's sometimes comfortable to get yaml format openapi document from Swagger UI.