### PR TITLE
Add configurable page title via dedicated Title option

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -276,7 +276,7 @@ const indexTemplate = `<!-- HTML for static distribution bundle build -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Swagger UI</title>
+  <title>{{.InstanceName}} | Swagger UI</title>
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />

--- a/swagger.go
+++ b/swagger.go
@@ -23,6 +23,7 @@ type Config struct {
 	DocExpansion         string
 	DomID                string
 	InstanceName         string
+	Title                string
 	DeepLinking          bool
 	PersistAuthorization bool
 	SyntaxHighlight      bool
@@ -86,6 +87,13 @@ func InstanceName(instanceName string) func(*Config) {
 	}
 }
 
+// Title specifies the HTML page title. Default is "Swagger UI".
+func Title(title string) func(*Config) {
+	return func(c *Config) {
+		c.Title = title
+	}
+}
+
 // PersistAuthorization Persist authorization information over browser close/refresh.
 // Defaults to false.
 func PersistAuthorization(persistAuthorization bool) func(*Config) {
@@ -106,6 +114,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		DocExpansion:         "list",
 		DomID:                "swagger-ui",
 		InstanceName:         "swagger",
+		Title:                "Swagger UI",
 		DeepLinking:          true,
 		PersistAuthorization: false,
 		SyntaxHighlight:      true,
@@ -276,7 +285,7 @@ const indexTemplate = `<!-- HTML for static distribution bundle build -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>{{.InstanceName}} | Swagger UI</title>
+  <title>{{.Title}}</title>
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -463,6 +463,26 @@ func TestInstanceNameV3(t *testing.T) {
 	assert.Equal(t, swagV3.Name, newCfg.InstanceName)
 }
 
+func TestTitle(t *testing.T) {
+	var cfg Config
+
+	expected := "custom-title"
+	Title(expected)(&cfg)
+	assert.Equal(t, expected, cfg.Title)
+
+	newCfg := newConfig()
+	assert.Equal(t, "Swagger UI", newCfg.Title)
+}
+
+func TestTitleRendered(t *testing.T) {
+	router := echo.New()
+	router.Any("/*", EchoWrapHandler(Title("My API")))
+
+	w := performRequest("GET", "/index.html", router)
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "<title>My API</title>")
+}
+
 func TestPersistAuthorization(t *testing.T) {
 	var cfg Config
 	expected := true


### PR DESCRIPTION
Make the Swagger UI HTML page title configurable.

Adds a `Title` config field and a `Title(...)` functional option. It defaults to `"Swagger UI"`, so the page title is unchanged unless explicitly set:

```go
e.GET("/swagger/*", echoSwagger.EchoWrapHandler(echoSwagger.Title("My API")))
```

This replaces the earlier `{{.InstanceName}} | Swagger UI` approach. A dedicated field is cleaner (per @svachaj's review feedback) and avoids regressing the default title to `swagger | Swagger UI` for users who don't set an instance name.

Related to #115