### PR TITLE
fix: Properly parse url in oauth callback

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -3,6 +3,7 @@ package echoSwagger
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"regexp"
 
@@ -188,7 +189,13 @@ func EchoWrapHandler(options ...func(*Config)) echo.HandlerFunc {
 			}
 			_, _ = c.Response().Writer.Write(doc)
 		default:
-			c.Request().URL.Path = matches[2]
+			parsedUrl, err := url.Parse(matches[2])
+			if err != nil {
+				c.Error(err)
+
+				return nil
+			}
+			c.Request().URL = parsedUrl
 			http.FileServer(http.FS(swaggerFiles.FS)).ServeHTTP(c.Response(), c.Request())
 		}
 


### PR DESCRIPTION
**Describe the PR**
When you authorize in Swagger UI using the `@securitydefinitions.oauth2.accessCode` it redirects to oauth2-redirect.html. Before this PR that page results in a 404. After the PR, the page is loaded correctly and the access token is stored ready to be used.

**Relation issue**
Fixes https://github.com/swaggo/echo-swagger/issues/106

