### PR TITLE
Custom Index Template

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -19,6 +19,7 @@ type Config struct {
 	DocExpansion         string
 	DomID                string
 	InstanceName         string
+	IndexTemplate        string
 	DeepLinking          bool
 	PersistAuthorization bool
 	SyntaxHighlight      bool
@@ -82,6 +83,13 @@ func InstanceName(instanceName string) func(*Config) {
 	}
 }
 
+// IndexTemplate overrides default index template
+func IndexTemplate(indexTemplate string) func(*Config) {
+	return func(c *Config) {
+		c.IndexTemplate = indexTemplate
+	}
+}
+
 // PersistAuthorization Persist authorization information over browser close/refresh.
 // Defaults to false.
 func PersistAuthorization(persistAuthorization bool) func(*Config) {
@@ -102,6 +110,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		DocExpansion:         "list",
 		DomID:                "swagger-ui",
 		InstanceName:         "swagger",
+		IndexTemplate:        indexTemplate,
 		DeepLinking:          true,
 		PersistAuthorization: false,
 		SyntaxHighlight:      true,
@@ -126,9 +135,9 @@ func EchoWrapHandler(options ...func(*Config)) echo.HandlerFunc {
 	config := newConfig(options...)
 
 	// create a template with name
-	index, _ := template.New("swagger_index.html").Parse(indexTemplate)
+	index, _ := template.New("swagger_index.html").Parse(config.IndexTemplate)
 
-	var re = regexp.MustCompile(`^(.*/)([^?].*)?[?|.]*$`)
+	re := regexp.MustCompile(`^(.*/)([^?].*)?[?|.]*$`)
 
 	return func(c echo.Context) error {
 		if c.Request().Method != http.MethodGet {

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -274,7 +274,6 @@ func TestWrapHandler(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPost, "/index.html", router).Code)
 
 	assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPut, "/index.html", router).Code)
-
 }
 
 func TestConfig(t *testing.T) {
@@ -404,6 +403,14 @@ func TestInstanceName(t *testing.T) {
 
 	newCfg := newConfig(InstanceName(""))
 	assert.Equal(t, swag.Name, newCfg.InstanceName)
+}
+
+func TestIndexTemplate(t *testing.T) {
+	var cfg Config
+
+	expected := "custom-index-template"
+	IndexTemplate(expected)(&cfg)
+	assert.Equal(t, expected, cfg.IndexTemplate)
 }
 
 func TestPersistAuthorization(t *testing.T) {


### PR DESCRIPTION
**Describe the PR**
Provide a config option to overwrite default index template with a custom one.

**Additional context**
I am wanting to remove the "Try it out" feature from my index template and make other changes. Currently the index string template is hardcoded and not open for expansion, this PR aims to give more expandability to this library.
