### PR TITLE
Bump swaggo/files/v2 to v2.0.2 to render OpenAPI 3.1 specs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/labstack/echo/v5 v5.0.0
 	github.com/stretchr/testify v1.11.1
-	github.com/swaggo/files/v2 v2.0.0
+	github.com/swaggo/files/v2 v2.0.2
 	github.com/swaggo/swag v1.16.2
 	github.com/swaggo/swag/v2 v2.0.0-rc4
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sv-tools/openapi v0.2.1 h1:ES1tMQMJFGibWndMagvdoo34T1Vllxr1Nlm5wz6b1aA=
 github.com/sv-tools/openapi v0.2.1/go.mod h1:k5VuZamTw1HuiS9p2Wl5YIDWzYnHG6/FgPOSFXLAhGg=
-github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw=
-github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
+github.com/swaggo/files/v2 v2.0.2 h1:Bq4tgS/yxLB/3nwOMcul5oLEUKa877Ykgz3CJMVbQKU=
+github.com/swaggo/files/v2 v2.0.2/go.mod h1:TVqetIzZsO9OhHX1Am9sRf9LdrFZqoK49N37KON/jr0=
 github.com/swaggo/swag v1.16.2 h1:28Pp+8DkQoV+HLzLx8RGJZXNGKbFqnuvSbAAtoxiY04=
 github.com/swaggo/swag v1.16.2/go.mod h1:6YzXnDcpr0767iOejs318CwYkCQqyGer6BizOg03f+E=
 github.com/swaggo/swag/v2 v2.0.0-rc4 h1:SZ8cK68gcV6cslwrJMIOqPkJELRwq4gmjvk77MrvHvY=


### PR DESCRIPTION
## Problem

`echo-swagger` v2 generates OpenAPI **3.1** specs (via `swag/v2`), but its `go.mod` pins `github.com/swaggo/files/v2 v2.0.0`, which embeds an older Swagger UI build that cannot render OpenAPI 3.1. The result is that the served UI loads but shows:

> Unable to render this definition
> The provided definition does not specify a valid version field.
> Please indicate a valid Swagger or OpenAPI version field. Supported version fields are `swagger: "2.0"` and those that match `openapi: 3.0.n`.

So a `swag/v2` + `echo-swagger` v2 setup produces a 3.1 spec that the bundled UI refuses to display.

## Fix

Bump `github.com/swaggo/files/v2` from `v2.0.0` to `v2.0.2`.

`files/v2 v2.0.1` [upgraded the bundled Swagger UI to v5.17.10](https://github.com/swaggo/files/releases/tag/v2.0.1), which renders OpenAPI 3.1; `v2.0.2` bumps it further. This is a `go.mod`/`go.sum`-only change.

## Verification

- `go build ./...` — passes
- `go test ./...` — passes (the existing asset-serving tests stay green)
- Verified end-to-end against a real `swag/v2`-generated `openapi: 3.1.0` spec: with `files/v2 v2.0.0` the UI shows the "valid version field" error; after bumping to `v2.0.2` (confirmed by asset hash that the new bundle is served) the spec renders correctly.

Relates to #113 (request to update the bundled Swagger UI).
